### PR TITLE
fix: Correct README styling reference to Tailwind CSS + shadcn/ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Comprehensive MERN stack CRM system with Telnyx voice agent integration for **Ma
 ## Architecture
 ```
 telnyx-mern-app/
-├── frontend/          # React application with Material-UI + Brand Style Guide
+├── frontend/          # React application with Tailwind CSS + shadcn/ui + Brand Style Guide
 ├── backend/           # Express.js API server with Socket.io
 ├── voice-agent/       # Existing Telnyx voice agent integration
 ├── databases/         # MongoDB, PostgreSQL, ChromaDB configurations


### PR DESCRIPTION
## Fix Styling Reference

**Issue:** Root README.md incorrectly referenced Material-UI as the frontend styling framework.

**Correction:** Changed to accurately reflect the tech stack:
- **Material-UI** ❌ (incorrect)
- **Tailwind CSS + shadcn/ui** ✅ (correct)

This aligns with:
- Magnificent Worldwide Marketing & Sales Group brand style guide
- Actual frontend implementation (React + Vite + Tailwind CSS)
- Brand colors: #3b82f6 (blue) to #facc15 (gold)
- Typography: Orbitron + Poppins fonts

**Changed:**
```diff
- ├── frontend/          # React application with Material-UI + Brand Style Guide
+ ├── frontend/          # React application with Tailwind CSS + shadcn/ui + Brand Style Guide
```